### PR TITLE
Ignore compiled variant filter_plugins/oct.pyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .bundle/
 vendor/
 Gemfile.lock
+filter_plugins/oct.pyc


### PR DESCRIPTION
Added this file to the .gitignore to prevent it from showing up in `git status` and/or being checking in by accident.